### PR TITLE
Extend characters set for PKCS11 URI

### DIFF
--- a/src/shared/pkcs11-util.c
+++ b/src/shared/pkcs11-util.c
@@ -31,7 +31,7 @@ bool pkcs11_uri_valid(const char *uri) {
         if (isempty(p))
                 return false;
 
-        if (!in_charset(p, ALPHANUMERICAL "-_?;&%="))
+        if (!in_charset(p, ALPHANUMERICAL ".~/-_?;&%="))
                 return false;
 
         return true;


### PR DESCRIPTION
There are tokens with dots (and other symbols) in PKCS11 URI:

pkcs11:model=Rutoken%20ECP;manufacturer=Aktiv%20Co.;serial=3xxxxxxb;token=livelace
pkcs11:model=PRO;manufacturer=Aladdin%20R.D.;serial=CC62FB25;token=val%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00;id=%33%32%31%30%33%61%36%37%36%65%32%34%35%62%32%31;type=private